### PR TITLE
I suggest to change terms to improve consistency

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -30,13 +30,13 @@ Usage
     marktime.start('some task')
     marktime.start('some another task')
 
-    marktime.stop('some task').seconds
+    marktime.stop('some task').sec
     8.757422924041748
 
-    marktime.stop('some another task').seconds
+    marktime.stop('some another task').sec
     14.805735111236572
 
-    marktime.duration('some another task').msecs
+    marktime.duration('some another task').msec
     14805.735111236572
 
     marktime.start('some task # 3')

--- a/marktime.py
+++ b/marktime.py
@@ -12,20 +12,20 @@ labels = {}
 
 class Duration(object):
 
-    def __init__(self, seconds):
-        self.value = seconds
+    def __init__(self, sec):
+        self.value = sec
 
     @property
-    def seconds(self):
+    def sec(self):
         return self.value
 
     @property
-    def msecs(self):
-        return self.seconds * 1000
+    def msec(self):
+        return self.sec * 1000
 
     @property
-    def minutes(self):
-        return self.seconds / 60
+    def min(self):
+        return self.sec / 60
 
 
 class Marker(object):
@@ -76,7 +76,7 @@ class Marker(object):
         }
 
         if add_duration or self.is_stopped():
-            export_data['duration'] = self.duration().seconds
+            export_data['duration'] = self.duration().sec
 
         return export_data
 

--- a/tests.py
+++ b/tests.py
@@ -16,11 +16,11 @@ class ApiTestCase(unittest.TestCase):
         mock_time.return_value = 123
         marktime.start('test run')
 
-        self.assertEquals(marktime.stop('test run', at=124).seconds, 1)
+        self.assertEquals(marktime.stop('test run', at=124).sec, 1)
 
     def test_start_stop_at(self):
         marktime.start('test run', at=123)
-        self.assertEquals(marktime.stop('test run', at=124).msecs, 1000)
+        self.assertEquals(marktime.stop('test run', at=124).msec, 1000)
 
     @mock.patch('marktime.time.time')
     def test_severals_markers(self, mock_time):
@@ -32,24 +32,24 @@ class ApiTestCase(unittest.TestCase):
 
         for i in range(1, markers_count):
             time_diff = marktime.stop('test run %d' % i,
-                                      at=(start_time + i)).seconds
+                                      at=(start_time + i)).sec
             self.assertEquals(time_diff, i)
 
     @mock.patch('marktime.time.time')
     def test_float_diffs(self, mock_time):
         mock_time.return_value = 123
         marktime.start('test run')
-        self.assertEquals(marktime.stop('test run', at=124.5).seconds, 1.5)
+        self.assertEquals(marktime.stop('test run', at=124.5).sec, 1.5)
 
     @mock.patch('marktime.time.time')
     def test_stop_twice(self, mock_time):
         mock_time.return_value = 123
         marktime.start('test run')
 
-        self.assertEquals(marktime.stop('test run', at=124).seconds, 1)
-        self.assertEquals(marktime.stop('test run', at=125).seconds, 1)
+        self.assertEquals(marktime.stop('test run', at=124).sec, 1)
+        self.assertEquals(marktime.stop('test run', at=125).sec, 1)
         self.assertEquals(marktime.stop('test run', at=183,
-                                        stop_once=False).minutes, 1)
+                                        stop_once=False).min, 1)
 
     @mock.patch('marktime.time.time')
     def test_real_times(self, mock_time):
@@ -60,7 +60,7 @@ class ApiTestCase(unittest.TestCase):
         mock_time.return_value = start_time
         marktime.start('test run')
         mock_time.return_value = stop_time
-        self.assertEquals(round(marktime.stop('test run').seconds, 4),
+        self.assertEquals(round(marktime.stop('test run').sec, 4),
                           round(diff_time, 4))
 
     def test_remove_from_labels(self):
@@ -76,7 +76,7 @@ class ApiTestCase(unittest.TestCase):
         mock_time.return_value = 123
         marktime.start('test run')
         time_diff = marktime.stop('test run', at=124,
-                                  remove_from_labels=False).seconds
+                                  remove_from_labels=False).sec
 
         self.assertEquals(marktime.labels['test run']['duration'], time_diff)
 
@@ -87,7 +87,7 @@ class ApiTestCase(unittest.TestCase):
 
         marktime.start('test run', at=start_time)
         marktime.stop('test run', at=stop_time)
-        self.assertEquals(marktime.duration('test run').seconds, diff_time)
+        self.assertEquals(marktime.duration('test run').sec, diff_time)
 
     def test_duration_None(self):
         marktime.start('test run')
@@ -101,7 +101,7 @@ class ApiTestCase(unittest.TestCase):
         marktime.start('test run', at=start_time)
         self.assertEquals(
             marktime.duration('test run', stop_it=True,
-                              stop_at=stop_time).seconds,
+                              stop_at=stop_time).sec,
             diff_time)
 
     def test_stop_label_not_exists(self):
@@ -116,7 +116,7 @@ class ApiTestCase(unittest.TestCase):
             time.sleep(diff_time)
 
         self.assertEquals(
-            round(marktime.duration('test_stopwatch').seconds, 2),
+            round(marktime.duration('test_stopwatch').sec, 2),
             round(diff_time, 2))
 
 
@@ -128,7 +128,7 @@ class InternalsTestCase(unittest.TestCase):
 
         self.assertEquals(
             round(marker.start().sleep(diff_time)
-                        .stop().duration().seconds, 2),
+                        .stop().duration().sec, 2),
             round(diff_time, 2))
 
     def test_continue(self):
@@ -154,5 +154,5 @@ class InternalsTestCase(unittest.TestCase):
         with marktime.Marker() as m:
             time.sleep(diff_time)
             self.assertEquals(
-                round(m.duration().seconds, 2),
+                round(m.duration().sec, 2),
                 round(diff_time, 2))


### PR DESCRIPTION
Hi I think it's better if we use terms similar to each other in the code.

Instead of seconds, msecs, minutes, "sec", "msec", and "min" look better.

It's just my opinion. Thansk !